### PR TITLE
✨feat:Add store settlement

### DIFF
--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreSettlement.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreSettlement.java
@@ -1,4 +1,62 @@
 package com.example.excluzscheduler.common.entity;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.example.excluzscheduler.domain.store.storeSettlement.enums.FeeRate;
+import com.example.excluzscheduler.domain.store.storeSettlement.enums.SettlementStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "store_settlement")
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class StoreSettlement {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
+
+	@Column(name = "settlements_period")
+	private LocalDate settlementPeriod;
+
+	@Column(name = "total_revenue")
+	private Long totalRevenue;
+
+	@Column(name = "platform_fee_rate")
+	@Enumerated(EnumType.STRING)
+	private FeeRate platformFeeRate;
+
+	@Column(name = "settlement_amount")
+	private Long settlementAmount;
+
+	@Column(name = "settlement_status")
+	@Enumerated(EnumType.STRING)
+	private SettlementStatus settlementStatus;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false, updatable = false)
+	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreSettlement.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreSettlement.java
@@ -14,12 +14,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,9 +33,8 @@ public class StoreSettlement {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "store_id")
-	private Store store;
+	@Column(name = "store_id")
+	private Integer storeId;
 
 	@Column(name = "settlements_period", nullable = false)
 	private LocalDate settlementPeriod; // 정산 내역 생성일
@@ -63,31 +59,24 @@ public class StoreSettlement {
 
 	@Builder
 	public StoreSettlement(
-		Store store,
+		Integer storeId,
 		Long totalRevenue,
 		FeeRate platformFeeRate,
-		Long settlementAmount,
-		LocalDateTime updatedAt
+		Long settlementAmount
 	) {
-		this.store=store;
+		this.storeId=storeId;
 		this.settlementPeriod=LocalDate.now();
 		this.totalRevenue=totalRevenue;
-		this.platformFeeRate=platformFeeRate;
+		this.platformFeeRate= platformFeeRate;
 		this.settlementAmount=settlementAmount;
 		this.settlementStatus=SettlementStatus.PENDING;
-		this.updatedAt=updatedAt;
-	}
-
-	public void updatePlatformFeeRate(FeeRate platformFeeRate) {
-		this.platformFeeRate = platformFeeRate;
+		this.updatedAt=LocalDateTime.now();
 	}
 
 	/* TODO 정산 완료 상태일 경우 이전 상태로 못 돌아가도록 기능 추가 필요 */
 	public void updateSettlementStatus(SettlementStatus settlementStatus) {
 		this.settlementStatus = settlementStatus;
+		this.updatedAt=LocalDateTime.now(); // 정산 상태 변경시 시간도 같이 업데이트
 	}
 
-	public void setUpdatedTime(LocalDateTime updatedAt) {
-		this.updatedAt=updatedAt;
-	}
 }

--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreSettlement.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreSettlement.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,24 +40,54 @@ public class StoreSettlement {
 	@JoinColumn(name = "store_id")
 	private Store store;
 
-	@Column(name = "settlements_period")
-	private LocalDate settlementPeriod;
+	@Column(name = "settlements_period", nullable = false)
+	private LocalDate settlementPeriod; // 정산 내역 생성일
 
-	@Column(name = "total_revenue")
+	@Column(name = "total_revenue", nullable = false)
 	private Long totalRevenue;
 
-	@Column(name = "platform_fee_rate")
+	@Column(name = "platform_fee_rate", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private FeeRate platformFeeRate;
 
-	@Column(name = "settlement_amount")
+	@Column(name = "settlement_amount", nullable = false)
 	private Long settlementAmount;
 
-	@Column(name = "settlement_status")
+	@Column(name = "settlement_status", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private SettlementStatus settlementStatus;
+	private SettlementStatus settlementStatus; // 정산 상태
 
 	@LastModifiedDate
-	@Column(name = "updated_at", nullable = false, updatable = false)
+	@Column(name = "updated_at", nullable = false)
 	private LocalDateTime updatedAt;
+
+	@Builder
+	public StoreSettlement(
+		Store store,
+		Long totalRevenue,
+		FeeRate platformFeeRate,
+		Long settlementAmount,
+		LocalDateTime updatedAt
+	) {
+		this.store=store;
+		this.settlementPeriod=LocalDate.now();
+		this.totalRevenue=totalRevenue;
+		this.platformFeeRate=platformFeeRate;
+		this.settlementAmount=settlementAmount;
+		this.settlementStatus=SettlementStatus.PENDING;
+		this.updatedAt=updatedAt;
+	}
+
+	public void updatePlatformFeeRate(FeeRate platformFeeRate) {
+		this.platformFeeRate = platformFeeRate;
+	}
+
+	/* TODO 정산 완료 상태일 경우 이전 상태로 못 돌아가도록 기능 추가 필요 */
+	public void updateSettlementStatus(SettlementStatus settlementStatus) {
+		this.settlementStatus = settlementStatus;
+	}
+
+	public void setUpdatedTime(LocalDateTime updatedAt) {
+		this.updatedAt=updatedAt;
+	}
 }

--- a/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
@@ -1,6 +1,8 @@
 package com.example.excluzscheduler.common.scheduler;
 
 import com.example.excluzscheduler.domain.store.storeRevenue.scheduler.StoreRevenueScheduler;
+import com.example.excluzscheduler.domain.store.storeSettlement.scheduler.StoreSettlementScheduler;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,13 +14,25 @@ import org.springframework.stereotype.Component;
 public class StoreScheduler {
 
     private final StoreRevenueScheduler storeRevenueScheduler;
+    private final StoreSettlementScheduler storeSettlementScheduler;
 
     // 매일 00:00:00 (자정) 실행 ("0 0 0 * * ?")
     @Scheduled(cron = "0 0 0 * * ?")
     public void scheduleStore() {
         log.info("start store scheduler");
+
         storeRevenueScheduler.createDailyRevenue();
 
         log.info("finish store scheduler");
+    }
+
+    // 매달 1일 자정 실행
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void scheduleStoreMonthly() {
+        log.info("start store scheduler monthly");
+
+        storeSettlementScheduler.createSettlement();
+
+        log.info("finish store scheduler monthly");
     }
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
@@ -1,8 +1,17 @@
 package com.example.excluzscheduler.domain.store.storeRevenue.repository;
 
+import java.util.List;
+
 import com.example.excluzscheduler.common.entity.StoreRevenue;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreRevenueRepository extends JpaRepository<StoreRevenue, Integer> {
 
+	@Query("SELECT sr.storeId, SUM(sr.totalRevenue) " +
+	"FROM StoreRevenue sr " +
+	"WHERE FUNCTION('MONTH', sr.startDate) = :prevMonth " +
+	"GROUP BY sr.storeId")
+	List<Object[]> findMonthlyTotalRevenue(@Param("prevMonth") int prevMonth);
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/enums/FeeRate.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/enums/FeeRate.java
@@ -1,0 +1,16 @@
+package com.example.excluzscheduler.domain.store.storeSettlement.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum FeeRate {
+	LOW(0.05),
+	MEDIUM(0.10),
+	HIGH(0.15);
+
+	private final Double feeRate;
+
+	FeeRate(Double feeRate) {
+		this.feeRate = feeRate;
+	}
+}

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/enums/SettlementStatus.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/enums/SettlementStatus.java
@@ -1,0 +1,16 @@
+package com.example.excluzscheduler.domain.store.storeSettlement.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum SettlementStatus {
+	PENDING("출금 요청 전"),
+	PROCESSING("스트리머 출금 요청"),
+	COMPLETED("출금 완료");
+
+	private final String description;
+
+	SettlementStatus(String description) {
+		this.description = description;
+	}
+}

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/repository/StoreSettlementRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/repository/StoreSettlementRepository.java
@@ -1,4 +1,8 @@
 package com.example.excluzscheduler.domain.store.storeSettlement.repository;
 
-public class StoreSettlementRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.excluzscheduler.common.entity.StoreSettlement;
+
+public interface StoreSettlementRepository extends JpaRepository<StoreSettlement, Integer> {
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/scheduler/StoreSettlementScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/scheduler/StoreSettlementScheduler.java
@@ -1,4 +1,27 @@
 package com.example.excluzscheduler.domain.store.storeSettlement.scheduler;
 
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+import com.example.excluzscheduler.domain.store.storeSettlement.service.StoreSettlementService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class StoreSettlementScheduler {
+
+	private final StoreSettlementService settlementService;
+
+	public void createSettlement() {
+		log.info("Create settlement");
+
+		int currentMonth = LocalDate.now().getDayOfMonth();
+		settlementService.createMonthlySettlement(currentMonth); // 월별 정산
+
+		log.info("Finish settlement");
+	}
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/service/StoreSettlementService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/service/StoreSettlementService.java
@@ -1,12 +1,14 @@
 package com.example.excluzscheduler.domain.store.storeSettlement.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.excluzscheduler.common.entity.StoreRevenue;
+import com.example.excluzscheduler.common.entity.StoreSettlement;
 import com.example.excluzscheduler.domain.store.storeRevenue.repository.StoreRevenueRepository;
+import com.example.excluzscheduler.domain.store.storeSettlement.enums.FeeRate;
 import com.example.excluzscheduler.domain.store.storeSettlement.repository.StoreSettlementRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -30,12 +32,34 @@ public class StoreSettlementService {
 		 *  */
 		// settlement_amount = (세틀먼트 테이블의 total_revenue) - (total 수수료)
 
-		int prevMonth = currentMonth-1;
+		int prevMonth = currentMonth - 1;
 
 		// 스토어별, 월별 총 매출액 리스트
 		List<Object[]> monthlyStoreRevenue = revenueRepository.findMonthlyTotalRevenue(prevMonth);
 
+		List<StoreSettlement> settlementList = new ArrayList<>();
 
+		for (Object[] row : monthlyStoreRevenue) {
+			int storeId = (int)row[0];
+			long totalRevenue = (long)row[1];
 
+			// 플랫폼 수수료 기본 10%로 계산 (수수료 산정 방식 지정 필요)
+			FeeRate feeRate = FeeRate.MEDIUM;
+			long platformFeeRate = (long)(feeRate.getFeeRate() * totalRevenue);
+
+			// 정산 금액
+			long settlementAmount = totalRevenue - platformFeeRate;
+
+			StoreSettlement newStoreSettlement = StoreSettlement.builder()
+				.storeId(storeId)
+				.totalRevenue(totalRevenue)
+				.settlementAmount(settlementAmount)
+				.platformFeeRate(feeRate)
+				.build();
+
+			settlementList.add(newStoreSettlement);
+		}
+
+		settlementRepository.saveAll(settlementList);
 	}
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/service/StoreSettlementService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeSettlement/service/StoreSettlementService.java
@@ -1,4 +1,41 @@
 package com.example.excluzscheduler.domain.store.storeSettlement.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.excluzscheduler.common.entity.StoreRevenue;
+import com.example.excluzscheduler.domain.store.storeRevenue.repository.StoreRevenueRepository;
+import com.example.excluzscheduler.domain.store.storeSettlement.repository.StoreSettlementRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class StoreSettlementService {
+
+	private final StoreSettlementRepository settlementRepository;
+	private final StoreRevenueRepository revenueRepository;
+
+	@Transactional
+	public void createMonthlySettlement(int currentMonth) {
+		// 로직 흐름
+		// currentMonth = 현재 월, 현재말고, 직전 월 매출을 정산해야한다. 직전 월 = currentMonth-1
+		// 스토어-레비뉴에서 월별(currentMonth-1) 매출액 집계 목록을 리스트 형식으로 들고온다.
+		/* total_revenue 만 싹 더한다. 이 값이 세틀먼트 테이블의 total_revenue 가 된다.
+		 *  이 때 스토어 아이디별로 따로 더해야한다.
+		 *  */
+		// settlement_amount = (세틀먼트 테이블의 total_revenue) - (total 수수료)
+
+		int prevMonth = currentMonth-1;
+
+		// 스토어별, 월별 총 매출액 리스트
+		List<Object[]> monthlyStoreRevenue = revenueRepository.findMonthlyTotalRevenue(prevMonth);
+
+
+
+	}
 }


### PR DESCRIPTION
## 목적
정산 기능 추가

## 변경점
- 매월 1일마다 '스토어 별 & 월 별' 정산 내역을 DB에 저장하는 로직을 구현했습니다.
- 수수료 산정 방식은 아직 정해지지 않아서 10%로 고정해두었습니다.
   - 혹시라도 추후 산정방식이 정해지면 서비스단에서 수정 가능하도록 구현해두었습니다.