### PR TITLE
:sparkles: feat: Implement store revenue ranking system

### DIFF
--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
@@ -4,11 +4,13 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -25,6 +27,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@EntityListeners(AuditingEntityListener.class) // @LastModifiedDate는 Spring Data JPA의 AuditingEntityListener를 활성화해야 적용됨
 @Table(name="store_rankings")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreRanking {

--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.LastModifiedDate;
 
+import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -46,7 +48,7 @@ public class StoreRanking {
 	// 매출 타입 (D, M, Y)
 	@Comment("매출 타입")
 	@Enumerated(EnumType.STRING)
-	private Period period;
+	private RevenuePeriod rankingPeriod;
 
 	// 랭킹 날짜
 	@LastModifiedDate
@@ -63,9 +65,9 @@ public class StoreRanking {
 
 	// 생성자: 매개변수 4개 이상은 빌더 패턴 사용
 	@Builder
-	public StoreRanking(Store store, Period period, Integer rankPosition, Long revenue) {
+	public StoreRanking(Store store, RevenuePeriod rankingPeriod, Integer rankPosition, Long revenue) {
 		this.store = store;
-		this.period = period;
+		this.rankingPeriod = rankingPeriod;
 		this.rankDate = LocalDateTime.now();
 		this.rankPosition = rankPosition;
 		this.revenue = revenue;

--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
@@ -1,4 +1,73 @@
 package com.example.excluzscheduler.common.entity;
 
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name="store_rankings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreRanking {
+
+	// StoreRanking 식별자
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	// store 식별자(외래키)
+	@ManyToOne(
+		fetch = FetchType.LAZY,
+		optional = false // store가 항상 필수 필드인 것을 명시
+	)
+	@JoinColumn(
+		name = "store_id",
+		nullable = false
+	)
+	private Store store;
+
+	// 매출 타입 (D, M, Y)
+	@Comment("매출 타입")
+	@Enumerated(EnumType.STRING)
+	private Period period;
+
+	// 랭킹 날짜
+	@LastModifiedDate
+	@Column(name = "rank_date", nullable = false)
+	private LocalDateTime rankDate;
+
+	// 랭킹 순위
+	@Column(name = "rank_position", nullable = false)
+	private Integer rankPosition;
+
+	// 매출
+	@Column(name = "revenue", nullable = false)
+	private Long revenue;
+
+	// 생성자: 매개변수 4개 이상은 빌더 패턴 사용
+	@Builder
+	public StoreRanking(Store store, Period period, Integer rankPosition, Long revenue) {
+		this.store = store;
+		this.period = period;
+		this.rankDate = LocalDateTime.now();
+		this.rankPosition = rankPosition;
+		this.revenue = revenue;
+	}
 }

--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreRanking.java
@@ -72,4 +72,11 @@ public class StoreRanking {
 		this.rankPosition = rankPosition;
 		this.revenue = revenue;
 	}
+
+	// 기존 랭킹 업데이트 메서드 추가
+	public void updateRank(Integer rankPosition, Long revenue) {
+		this.rankPosition = rankPosition;
+		this.revenue = revenue;
+		this.rankDate = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
@@ -1,5 +1,7 @@
 package com.example.excluzscheduler.common.scheduler;
 
+import com.example.excluzscheduler.domain.store.storeRanking.scheduler.StoreRankingScheduler;
+import com.example.excluzscheduler.domain.store.storeRanking.service.StoreRankingService;
 import com.example.excluzscheduler.domain.store.storeRevenue.scheduler.StoreRevenueScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,12 +14,16 @@ import org.springframework.stereotype.Component;
 public class StoreScheduler {
 
     private final StoreRevenueScheduler storeRevenueScheduler;
+    private final StoreRankingService storeRankingService;
 
     // 매일 00:00:00 (자정) 실행 ("0 0 0 * * ?")
-    @Scheduled(cron = "0 0 0 * * ?")
+    // @Scheduled(cron = "0 0 0 * * ?")
+    // todo 동작 완료 후 특정한 시간 지난 이후에 실행되도록 하기
+    @Scheduled(cron = "0 */1 * * * *") // todo 현재 테스트 위해 매분 실행으로 세팅함 (cron으로 시간 안 정하고 할 수 있음 -> fixedRate, fixedDelay 공부해서 적용하기)
     public void scheduleStore() {
         log.info("start store scheduler");
         storeRevenueScheduler.createDailyRevenue();
+        storeRankingService.updateDailyStoreRankings();
 
         log.info("finish store scheduler");
     }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/StoreRankingController.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/StoreRankingController.java
@@ -1,0 +1,25 @@
+package com.example.excluzscheduler.domain.store.storeRanking;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
+import com.example.excluzscheduler.domain.store.storeRanking.service.StoreRankingService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/store-ranking")
+@RequiredArgsConstructor
+public class StoreRankingController {
+	private final StoreRankingService storeRankingService;
+
+	// 매일 자정마다 실행되는 스케줄러 (TOP 10 랭킹 업데이트)
+	@GetMapping("/top10")
+	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings() {
+		return storeRankingService.getTop10StoreRankings();
+	}
+}

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/dto/response/StoreRankingResponseDto.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/dto/response/StoreRankingResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.excluzscheduler.domain.store.storeRanking.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class StoreRankingResponseDto {
+
+	private final Integer storeId;     // 스토어 ID
+	private final String storeName;    // 스토어 이름
+	private final Long totalRevenue;   // 총 매출
+	private final int rank;            // 순위
+
+	// 매개변수 4개 이하 -> 생성자 직접 작성
+	public StoreRankingResponseDto(Integer storeId, String storeName, Long totalRevenue, int rank) {
+		this.storeId = storeId;
+		this.storeName = storeName;
+		this.totalRevenue = totalRevenue;
+		this.rank = rank;
+	}
+}

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/dto/response/StoreRankingTop10ResponseDto.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/dto/response/StoreRankingTop10ResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.excluzscheduler.domain.store.storeRanking.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class StoreRankingTop10ResponseDto {
+	private final Integer storeId;  // 스토어 ID
+	private final String storeName;  // 스토어 이름
+	private final int rank;  // 순위
+
+	// 매개변수 4개 미만일 때는 직접 생성자 추가
+	public StoreRankingTop10ResponseDto(Integer storeId, String storeName, int rank) {
+		this.storeId = storeId;
+		this.storeName = storeName;
+		this.rank = rank;
+	}
+}

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/repository/StoreRankingRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/repository/StoreRankingRepository.java
@@ -1,4 +1,33 @@
 package com.example.excluzscheduler.domain.store.storeRanking.repository;
 
-public class StoreRankingRepository {
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.excluzscheduler.common.entity.Store;
+import com.example.excluzscheduler.common.entity.StoreRanking;
+import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
+import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
+
+@Repository
+public interface StoreRankingRepository extends JpaRepository<StoreRanking, Long> {
+
+	// 일간 TOP 10 조회 (JPA Pageable 사용)
+	@Query("SELECT new com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto(s.id, s.name, " +
+		"RANK() OVER (ORDER BY SUM(sr.revenue) DESC)) " +
+		"FROM StoreRevenue sr " +
+		"JOIN sr.store s " +
+		"WHERE sr.period = :period " +
+		"AND sr.startDate <= CURRENT_DATE AND sr.endDate >= CURRENT_DATE " +
+		"GROUP BY s.id, s.name " +
+		"ORDER BY SUM(sr.revenue) DESC")
+	List<StoreRankingTop10ResponseDto> findTop10StoresForPublic(@Param("period") RevenuePeriod period, Pageable pageable);
+
+	// 기존 랭킹 존재 여부 확인 (업데이트를 위해)
+	Optional<StoreRanking> findByStoreAndPeriod(Store store, RevenuePeriod period);
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/repository/StoreRankingRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/repository/StoreRankingRepository.java
@@ -1,8 +1,8 @@
 package com.example.excluzscheduler.domain.store.storeRanking.repository;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,23 +11,15 @@ import org.springframework.stereotype.Repository;
 
 import com.example.excluzscheduler.common.entity.Store;
 import com.example.excluzscheduler.common.entity.StoreRanking;
-import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
 import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
 
 @Repository
 public interface StoreRankingRepository extends JpaRepository<StoreRanking, Long> {
 
-	// 일간 TOP 10 조회 (JPA Pageable 사용)
-	@Query("SELECT new com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto(s.id, s.name, " +
-		"RANK() OVER (ORDER BY SUM(sr.revenue) DESC)) " +
-		"FROM StoreRevenue sr " +
-		"JOIN sr.store s " +
-		"WHERE sr.period = :period " +
-		"AND sr.startDate <= CURRENT_DATE AND sr.endDate >= CURRENT_DATE " +
-		"GROUP BY s.id, s.name " +
-		"ORDER BY SUM(sr.revenue) DESC")
-	List<StoreRankingTop10ResponseDto> findTop10StoresForPublic(@Param("period") RevenuePeriod period, Pageable pageable);
+	// 기존 랭킹 존재 여부 확인
+	Optional<StoreRanking> findByStoreAndRankingPeriod(Store store, RevenuePeriod rankingPeriod);
 
-	// 기존 랭킹 존재 여부 확인 (업데이트를 위해)
-	Optional<StoreRanking> findByStoreAndPeriod(Store store, RevenuePeriod period);
+	// TOP 10 랭킹 조회 (매출 정보 없이 반환)
+	@Query("SELECT sr FROM StoreRanking sr WHERE sr.rankingPeriod = :period ORDER BY sr.rankPosition ASC")
+	Page<StoreRanking> findTop10ByRankingPeriod(@Param("period") RevenuePeriod period, Pageable pageable);
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/scheduler/StoreRankingScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/scheduler/StoreRankingScheduler.java
@@ -1,28 +1,37 @@
 package com.example.excluzscheduler.domain.store.storeRanking.scheduler;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.scheduling.annotation.Scheduled;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Component;
 
 import com.example.excluzscheduler.domain.store.storeRanking.service.StoreRankingService;
+import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 // @Profile("batch") // <- batch 말고 다른 이름으로 명명하고 싶으면 바꿔도 됨
 // spring.profiles.active 값이 batch 일 때만 지금 StoreRankingScheduler Bean 이 생성되고, 그 때문에 spring.profiles.active 값이 batch 가 아닌 경우에는 해당 Bean 이 생성이 안되니까 스케쥴링해둔 게 안돈다
 // 로컬에서 스케쥴러를 테스트할때에는 Intellij 에서 Edit Configurations 를 눌러서 activeProfiles 라는 곳에 batch 를 넣어두고 테스트하면 된다.
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
-public class StoreRankingScheduler {
+public class StoreRankingScheduler { // todo 클래스 이름 바꾸기! 서비스로! (함수를 서비스로 넘기기)
+
 	private final StoreRankingService storeRankingService;
 
-	// 공식 랭킹 TOP 10: 인증 X (누구나 확인 가능)
-	// @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
-	@Scheduled(cron = "0 */1 * * * *") // todo 현재 테스트 위해 매분 실행으로 세팅함
+	// 매일 자정마다 실행되는 스케줄러 (TOP 10 랭킹 업데이트)
 	public void updateDailyStoreRankings() {
-		storeRankingService.updateDailyRankings();
+		log.info("🟢 일간 랭킹 업데이트 시작");
+
+		RevenuePeriod rankingPeriod = RevenuePeriod.D; // 일간 매출 기준 랭킹
+		LocalDateTime startDate = LocalDate.now().minusDays(1).atStartOfDay();
+		LocalDateTime endDate = LocalDate.now().atStartOfDay();
+
+		storeRankingService.createDailyRanking(rankingPeriod, startDate, endDate);
+
+		log.info("✅ 일간 랭킹 업데이트 완료!");
 	}
-
-
-
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/scheduler/StoreRankingScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/scheduler/StoreRankingScheduler.java
@@ -1,4 +1,28 @@
 package com.example.excluzscheduler.domain.store.storeRanking.scheduler;
 
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.example.excluzscheduler.domain.store.storeRanking.service.StoreRankingService;
+
+import lombok.RequiredArgsConstructor;
+
+// @Profile("batch") // <- batch 말고 다른 이름으로 명명하고 싶으면 바꿔도 됨
+// spring.profiles.active 값이 batch 일 때만 지금 StoreRankingScheduler Bean 이 생성되고, 그 때문에 spring.profiles.active 값이 batch 가 아닌 경우에는 해당 Bean 이 생성이 안되니까 스케쥴링해둔 게 안돈다
+// 로컬에서 스케쥴러를 테스트할때에는 Intellij 에서 Edit Configurations 를 눌러서 activeProfiles 라는 곳에 batch 를 넣어두고 테스트하면 된다.
+@Component
+@RequiredArgsConstructor
 public class StoreRankingScheduler {
+	private final StoreRankingService storeRankingService;
+
+	// 공식 랭킹 TOP 10: 인증 X (누구나 확인 가능)
+	// @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+	@Scheduled(cron = "0 */1 * * * *") // todo 현재 테스트 위해 매분 실행으로 세팅함
+	public void updateDailyStoreRankings() {
+		storeRankingService.updateDailyRankings();
+	}
+
+
+
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
@@ -1,4 +1,56 @@
 package com.example.excluzscheduler.domain.store.storeRanking.service;
 
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.excluzscheduler.common.entity.Store;
+import com.example.excluzscheduler.common.entity.StoreRanking;
+import com.example.excluzscheduler.domain.store.store.repository.StoreRepository;
+import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
+import com.example.excluzscheduler.domain.store.storeRanking.repository.StoreRankingRepository;
+import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class StoreRankingService {
+	private final StoreRankingRepository storeRankingRepository;
+	private final StoreRepository storeRepository;
+
+	// 공식 랭킹 TOP 10: 인증 X (누구나 확인 가능)
+	@Transactional
+	public List<StoreRankingTop10ResponseDto> updateDailyRankings() {
+		// 매출 기준으로 TOP 10 조회
+		List<StoreRankingTop10ResponseDto> topStores = storeRankingRepository.findTop10StoresForPublic(
+			RevenuePeriod.D, PageRequest.of(0, 10)
+		);
+
+		// 랭킹 계산 및 저장 (기존 데이터가 있으면 업데이트)
+		IntStream.range(0, topStores.size()).forEach(i -> {
+			StoreRankingTop10ResponseDto dto = topStores.get(i);
+			Store store = storeRepository.findById(dto.getStoreId())
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스토어 ID: " + dto.getStoreId()));
+
+			StoreRanking ranking = storeRankingRepository.findByStoreAndPeriod(store, RevenuePeriod.D)
+				.map(existingRanking -> {
+					existingRanking.updateRank(i + 1, dto.getRevenue()); // 기존 랭킹 업데이트
+					return existingRanking;
+				})
+				.orElse(StoreRanking.builder() // 새로운 랭킹 생성
+					.store(store)
+					.rankingPeriod(RevenuePeriod.D)
+					.rankPosition(i + 1)
+					.revenue(dto.getRevenue())
+					.build());
+
+			storeRankingRepository.save(ranking);
+		});
+
+		return topStores;
+	}
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
@@ -1,7 +1,9 @@
 package com.example.excluzscheduler.domain.store.storeRanking.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.IntStream;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -9,48 +11,109 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.excluzscheduler.common.entity.Store;
 import com.example.excluzscheduler.common.entity.StoreRanking;
+import com.example.excluzscheduler.common.entity.StoreRevenue;
 import com.example.excluzscheduler.domain.store.store.repository.StoreRepository;
 import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
 import com.example.excluzscheduler.domain.store.storeRanking.repository.StoreRankingRepository;
 import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
+import com.example.excluzscheduler.domain.store.storeRevenue.repository.StoreRevenueRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StoreRankingService {
+	private final StoreRevenueRepository storeRevenueRepository;
 	private final StoreRankingRepository storeRankingRepository;
 	private final StoreRepository storeRepository;
 
-	// 공식 랭킹 TOP 10: 인증 X (누구나 확인 가능)
+	// 매일 자정마다 실행되는 스케줄러 (TOP 10 랭킹 업데이트)
+	public void updateDailyStoreRankings() {
+		log.info("🟢 일간 랭킹 업데이트 시작");
+
+		RevenuePeriod rankingPeriod = RevenuePeriod.D; // 일간 매출 기준 랭킹
+		LocalDateTime startDate = LocalDate.now().minusDays(1).atStartOfDay();
+		LocalDateTime endDate = LocalDate.now().atStartOfDay();
+
+		createDailyRanking(rankingPeriod, startDate, endDate);
+
+		log.info("✅ 일간 랭킹 업데이트 완료!");
+	}
+
+	// 매일 자정마다 실행되는 스케줄러 (TOP 10 랭킹 업데이트)
+	/**
+	 * 1. 매출이 동일할 경우 동일한 등수로 표시
+	 * 2. 매출이 동일하지 않은 이후 스토어가 있는 경우, (동일한 등수 + 동일한 스토어의 수) 만큼의 등수를 얻는다 -> 1등이 2개면, 다음 등수는 3등 처리
+ 	 */
 	@Transactional
-	public List<StoreRankingTop10ResponseDto> updateDailyRankings() {
-		// 매출 기준으로 TOP 10 조회
-		List<StoreRankingTop10ResponseDto> topStores = storeRankingRepository.findTop10StoresForPublic(
-			RevenuePeriod.D, PageRequest.of(0, 10)
-		);
+	public void createDailyRanking(RevenuePeriod rankingPeriod, LocalDateTime startDate, LocalDateTime endDate) {
+		log.info("🔍 매출 기준 TOP10 가져오는 중...");
 
-		// 랭킹 계산 및 저장 (기존 데이터가 있으면 업데이트)
-		IntStream.range(0, topStores.size()).forEach(i -> {
-			StoreRankingTop10ResponseDto dto = topStores.get(i);
-			Store store = storeRepository.findById(dto.getStoreId())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스토어 ID: " + dto.getStoreId()));
+		// 어제 매출 기준으로 TOP 10 스토어 조회
+		List<StoreRevenue> topStores = storeRevenueRepository.findStoresByRevenue(startDate.toLocalDate(), endDate.toLocalDate());
 
-			StoreRanking ranking = storeRankingRepository.findByStoreAndPeriod(store, RevenuePeriod.D)
-				.map(existingRanking -> {
-					existingRanking.updateRank(i + 1, dto.getRevenue()); // 기존 랭킹 업데이트
-					return existingRanking;
-				})
-				.orElse(StoreRanking.builder() // 새로운 랭킹 생성
+		if (topStores.isEmpty()) {
+			log.info("⚠️ 매출 데이터가 없습니다. 랭킹을 업데이트하지 않습니다.");
+			return;
+		}
+
+		int currentRank = 1;
+
+		// 이전 매출 저장
+		Long preStoreRevenue = -1L; // 초기화
+
+		int preStoreRank = currentRank;
+
+		for (StoreRevenue revenue : topStores) {
+			Store store = storeRepository.findById(revenue.getStoreId())
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스토어입니다.")); // todo 추후 커스텀 익셉션 처리
+
+			int rank = currentRank;
+
+			if (preStoreRevenue.equals(revenue.getTotalRevenue())) {
+				rank = preStoreRank;
+			}
+
+			// 기존 랭킹 존재 여부 확인
+			StoreRanking existingRanking = storeRankingRepository.findByStoreAndRankingPeriod(store, rankingPeriod)
+				.orElse(null);
+
+			if (existingRanking != null) {
+				// 기존 랭킹 업데이트
+				existingRanking.updateRank(rank, revenue.getTotalRevenue());
+			} else {
+				// 새로운 랭킹 생성
+				StoreRanking newRanking = StoreRanking.builder()
 					.store(store)
-					.rankingPeriod(RevenuePeriod.D)
-					.rankPosition(i + 1)
-					.revenue(dto.getRevenue())
-					.build());
+					.rankingPeriod(rankingPeriod)
+					.rankPosition(rank)
+					.revenue(revenue.getTotalRevenue())
+					.build();
 
-			storeRankingRepository.save(ranking);
-		});
+				storeRankingRepository.save(newRanking);
+			}
 
-		return topStores;
+			preStoreRevenue = revenue.getTotalRevenue();
+			preStoreRank = rank;
+
+			currentRank++;
+		}
+
+		log.info("✅ 일간 랭킹 업데이트 완료");
+	}
+
+	// TOP 10 랭킹 조회 (매출 정보 제외)
+	@Transactional(readOnly = true)
+	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings() {
+		return storeRankingRepository.findTop10ByRankingPeriod(RevenuePeriod.D, PageRequest.of(0, 10))
+			.getContent()
+			.stream()
+			.map(ranking -> new StoreRankingTop10ResponseDto(
+				ranking.getStore().getId(),
+				ranking.getStore().getStoreName(),
+				ranking.getRankPosition()))
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
@@ -1,8 +1,17 @@
 package com.example.excluzscheduler.domain.store.storeRevenue.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import com.example.excluzscheduler.common.entity.StoreRevenue;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreRevenueRepository extends JpaRepository<StoreRevenue, Integer> {
 
+	// 매출 기준으로 스토어 조회
+	@Query("SELECT sr FROM StoreRevenue sr WHERE sr.startDate >= :startDate AND sr.endDate < :endDate ORDER BY sr.totalRevenue DESC")
+	List<StoreRevenue> findStoresByRevenue(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 }


### PR DESCRIPTION
## 목적
매출 기반 스토어 랭킹 시스템을 구현하여, 상점의 매출 데이터를 활용한 정렬 및 조회 기능을 제공.

## 변경점
- StoreRanking 엔티티 및 관련 DTO (StoreRankingResponseDto, StoreRankingTop10ResponseDto) 추가
- StoreRevenue 데이터를 활용하여 스토어별 매출 기준 랭킹 계산 기능 구현
- StoreRevenueService를 통해 주문 시 매출 데이터 업데이트 처리 반영
- 랭킹 데이터 정렬 및 조회 API 추가 (StoreRankingController)
- 기존 매출 로직 리팩토링 (StoreRevenueRepository, StoreRevenueService 개선)