### PR TITLE
♻️ Fix Feature/store revenue due to complex key

### DIFF
--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreRevenue.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreRevenue.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Table(name = "store_revenues")
@@ -17,25 +15,12 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 public class StoreRevenue {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
 
-    @Column(name = "store_id", nullable = false)
-    private Integer storeId;
+    @EmbeddedId
+    private StoreRevenueId id;
 
     @Column(name = "total_revenue", nullable = false)
     private Long totalRevenue;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "revenue_period", nullable = false)
-    private RevenuePeriod revenuePeriod;
-
-    @Column(name = "start_datetime", nullable = false)
-    private LocalDateTime startDatetime;
-
-    @Column(name = "end_datetime", nullable = false)
-    private LocalDateTime endDatetime;
 
     @CreatedDate
     @Column(updatable = false, nullable = false)
@@ -44,15 +29,28 @@ public class StoreRevenue {
     @Builder
     public StoreRevenue(
             Integer storeId,
-            Long totalRevenue,
             RevenuePeriod revenuePeriod,
             LocalDateTime startDatetime,
-            LocalDateTime endDatetime
+            LocalDateTime endDatetime,
+            Long totalRevenue
     ) {
-        this.storeId = storeId;
+        this.id = new StoreRevenueId(storeId, revenuePeriod, startDatetime, endDatetime);
         this.totalRevenue = totalRevenue;
-        this.revenuePeriod = revenuePeriod;
-        this.startDatetime = startDatetime;
-        this.endDatetime = endDatetime;
+    }
+
+    public Integer getStoreId() {
+        return id.getStoreId();
+    }
+
+    public RevenuePeriod getRevenuePeriod() {
+        return id.getRevenuePeriod();
+    }
+
+    public LocalDateTime getStartDatetime() {
+        return id.getStartDatetime();
+    }
+
+    public LocalDateTime getEndDatetime() {
+        return id.getEndDatetime();
     }
 }

--- a/src/main/java/com/example/excluzscheduler/common/entity/StoreRevenueId.java
+++ b/src/main/java/com/example/excluzscheduler/common/entity/StoreRevenueId.java
@@ -1,0 +1,27 @@
+package com.example.excluzscheduler.common.entity;
+
+import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Embeddable
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoreRevenueId implements Serializable {
+
+    private Integer storeId;
+
+    @Enumerated(EnumType.STRING)
+    private RevenuePeriod revenuePeriod;
+
+    private LocalDateTime startDatetime;
+    private LocalDateTime endDatetime;
+}

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
@@ -12,6 +12,6 @@ import org.springframework.data.repository.query.Param;
 public interface StoreRevenueRepository extends JpaRepository<StoreRevenue, Integer> {
 
 	// 매출 기준으로 스토어 조회
-	@Query("SELECT sr FROM StoreRevenue sr WHERE sr.startDatetime >= :startDate AND sr.endDatetime < :endDate ORDER BY sr.totalRevenue DESC")
+	@Query("SELECT sr FROM StoreRevenue sr WHERE sr.id.startDatetime >= :startDate AND sr.id.endDatetime < :endDate ORDER BY sr.totalRevenue DESC")
 	List<StoreRevenue> findStoresByRevenue(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }


### PR DESCRIPTION
## 목적
- evenue_period, start_datetime, end_datetime에 따라 유일하게 1개의 매출액이 집계가 되도록 개선
- 복합키를 사용하여 기존 데이터가 있으면 하나의 데이터가 덮혀져 저장

## 변경점
- 매출액 id 엔티티 추가
- 리파지토리 조금 수정
- 매출액 엔티티 수정