### PR TITLE
♻️ refactor: Enhance store revenue ranking and scheduler functionality

### DIFF
--- a/src/main/java/com/example/excluzscheduler/common/scheduler/SchedulerSkipTime.java
+++ b/src/main/java/com/example/excluzscheduler/common/scheduler/SchedulerSkipTime.java
@@ -1,0 +1,32 @@
+package com.example.excluzscheduler.common.scheduler;
+
+import lombok.Getter;
+
+@Getter
+public enum SchedulerSkipTime {
+    REAL_TIME_SKIP(
+        3,  // SKIP_HOUR: 새벽 3시
+        0,  // SKIP_MINUTE_START: 0분
+        20  // SKIP_MINUTE_END: 20분
+    );
+
+    private final int skipHour;
+    private final int skipMinuteStart;
+    private final int skipMinuteEnd;
+
+    SchedulerSkipTime(int skipHour, int skipMinuteStart, int skipMinuteEnd) {
+        this.skipHour = skipHour;
+        this.skipMinuteStart = skipMinuteStart;
+        this.skipMinuteEnd = skipMinuteEnd;
+    }
+
+    /**
+     * 주어진 시간이 스킵 시간 범위 내에 있는지 확인
+     * @param hour 현재 시간 (0-23)
+     * @param minute 현재 분 (0-59)
+     * @return true if 시간 범위 내에 있음
+     */
+    public boolean isWithinSkipRange(int hour, int minute) {
+        return hour == skipHour && minute >= skipMinuteStart && minute <= skipMinuteEnd;
+    }
+}

--- a/src/main/java/com/example/excluzscheduler/common/scheduler/SchedulerSkipTime.java
+++ b/src/main/java/com/example/excluzscheduler/common/scheduler/SchedulerSkipTime.java
@@ -7,7 +7,7 @@ public enum SchedulerSkipTime {
     REAL_TIME_SKIP(
         3,  // SKIP_HOUR: 새벽 3시
         0,  // SKIP_MINUTE_START: 0분
-        20  // SKIP_MINUTE_END: 20분
+        30  // SKIP_MINUTE_END: 30분
     );
 
     private final int skipHour;

--- a/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
@@ -16,11 +16,13 @@ import java.time.LocalDateTime;
 @Component
 @RequiredArgsConstructor
 public class StoreScheduler {
-
-
     private final StoreRevenueService storeRevenueService;
     private final StoreRankingService storeRankingService;
     private final StoreSettlementService storeSettlementService;
+
+    private static final String CRON_DAILY = "0 0 3 * * *";
+    private static final String CRON_MONTHLY = "0 10 3 1 * *";
+    private static final String CRON_YEARLY = "0 20 3 1 1 *";
 
     private void executeScheduler(RevenuePeriod revenuePeriod) {
         LocalDateTime nowDatetime = LocalDateTime.now();
@@ -44,8 +46,20 @@ public class StoreScheduler {
     public void scheduleRealTimeRevenueUpdate() {
 
         LocalDateTime nowDatetime = LocalDateTime.now();
-        RevenuePeriod revenuePeriod = RevenuePeriod.DAY; // 테스트할 기간 선택
+        int hour = nowDatetime.getHour();
+        int minute = nowDatetime.getMinute();
 
+        // 새벽 3시 0분 ~ 3시 20분 사이에는 실행하지 않음
+        if (SchedulerSkipTime.REAL_TIME_SKIP.isWithinSkipRange(hour, minute)) {
+            log.info("🕒 새벽 {}시 {}분 ~ {}분 사이에는 실시간 스케줄러를 실행하지 않습니다.",
+                SchedulerSkipTime.REAL_TIME_SKIP.getSkipHour(),
+                SchedulerSkipTime.REAL_TIME_SKIP.getSkipMinuteStart(),
+                SchedulerSkipTime.REAL_TIME_SKIP.getSkipMinuteEnd());
+            return;
+        }
+
+        // 테스트할 기간 선택
+        RevenuePeriod revenuePeriod = RevenuePeriod.DAY;
         LocalDateTime startDatetime = revenuePeriod.getStartDatetime(nowDatetime).plusDays(1); // 당일
         LocalDateTime endDatetime = revenuePeriod.getEndDatetime(nowDatetime).plusDays(1); // 내일
 
@@ -58,19 +72,19 @@ public class StoreScheduler {
     }
 
     // 일간 - 사용자가 사용하지 않는 시간에 돌도록 하기
-    @Scheduled(cron = "0 0 3 * * *") // 매 새벽 3시
+    @Scheduled(cron = CRON_DAILY) // 매 새벽 3시
     public void scheduleDailyRevenueUpdate() {
         executeScheduler(RevenuePeriod.DAY);
     }
 
     // 월간
-    @Scheduled(cron = "0 0 3 1 * *") // 매월 1일 새벽 3시
+    @Scheduled(cron = CRON_MONTHLY) // 매월 1일 새벽 3시 10분
     public void scheduleMonthlyRevenueUpdate() {
         executeScheduler(RevenuePeriod.MONTH);
     }
 
     // 연간
-    @Scheduled(cron = "0 0 3 1 1 *") // 매년 1월 1일 새벽 3시
+    @Scheduled(cron = CRON_YEARLY) // 매년 1월 1일 새벽 3시 20분
     public void scheduleYearlyRevenueUpdate() {
         executeScheduler(RevenuePeriod.YEAR);
     }

--- a/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
@@ -22,23 +22,56 @@ public class StoreScheduler {
     private final StoreRankingService storeRankingService;
     private final StoreSettlementService storeSettlementService;
 
-    @Scheduled(fixedDelay = 30000) // 로직 작업 끝나고 30초 뒤 로직 돌아감
-
-    public void scheduleStore() {
-
+    private void executeScheduler(RevenuePeriod revenuePeriod) {
         LocalDateTime nowDatetime = LocalDateTime.now();
-        RevenuePeriod revenuePeriod = RevenuePeriod.MINUTE_1; // 테스트할 기간 선택
-
         LocalDateTime startDatetime = revenuePeriod.getStartDatetime(nowDatetime);
         LocalDateTime endDatetime = revenuePeriod.getEndDatetime(nowDatetime);
 
-        log.info("start store scheduler");
+        log.info("🖍️ {} 스케줄러 시작", revenuePeriod);
 
         storeRevenueService.createRevenue(revenuePeriod, startDatetime, endDatetime);
-        storeRankingService.updateDailyStoreRankings(revenuePeriod, startDatetime, endDatetime);
-        storeSettlementService.createSettlement(revenuePeriod, startDatetime, endDatetime); // TODO 테스트 이후 월별 정산으로 매개변수 변경 필요
+        storeRankingService.updateStoreRankings(revenuePeriod, startDatetime, endDatetime);
 
-        log.info("finish store scheduler");
+        if (revenuePeriod == RevenuePeriod.MONTH) {
+            storeSettlementService.createSettlement(revenuePeriod, startDatetime, endDatetime);
+        }
+
+        log.info("🟢 {} 스케줄러 끝", revenuePeriod);
     }
 
+    // 실시간
+    @Scheduled(fixedDelay = 60000)
+    public void scheduleRealTimeRevenueUpdate() {
+
+        LocalDateTime nowDatetime = LocalDateTime.now();
+        RevenuePeriod revenuePeriod = RevenuePeriod.DAY; // 테스트할 기간 선택
+
+        LocalDateTime startDatetime = revenuePeriod.getStartDatetime(nowDatetime).plusDays(1); // 당일
+        LocalDateTime endDatetime = revenuePeriod.getEndDatetime(nowDatetime).plusDays(1); // 내일
+
+        log.info("🖍️ 실시간 스케줄러 시작");
+
+        storeRevenueService.createRevenue(revenuePeriod, startDatetime, endDatetime);
+        storeRankingService.updateStoreRankings(revenuePeriod, startDatetime, endDatetime);
+
+        log.info("🟢 실시간 스케줄러 끝");
+    }
+
+    // 일간 - 사용자가 사용하지 않는 시간에 돌도록 하기
+    @Scheduled(cron = "0 0 3 * * *") // 매 새벽 3시
+    public void scheduleDailyRevenueUpdate() {
+        executeScheduler(RevenuePeriod.DAY);
+    }
+
+    // 월간
+    @Scheduled(cron = "0 0 3 1 * *") // 매월 1일 새벽 3시
+    public void scheduleMonthlyRevenueUpdate() {
+        executeScheduler(RevenuePeriod.MONTH);
+    }
+
+    // 연간
+    @Scheduled(cron = "0 0 3 1 1 *") // 매년 1월 1일 새벽 3시
+    public void scheduleYearlyRevenueUpdate() {
+        executeScheduler(RevenuePeriod.YEAR);
+    }
 }

--- a/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
+++ b/src/main/java/com/example/excluzscheduler/common/scheduler/StoreScheduler.java
@@ -49,7 +49,7 @@ public class StoreScheduler {
         int hour = nowDatetime.getHour();
         int minute = nowDatetime.getMinute();
 
-        // 새벽 3시 0분 ~ 3시 20분 사이에는 실행하지 않음
+        // 새벽 3시 0분 ~ 3시 30분 사이에는 실행하지 않음
         if (SchedulerSkipTime.REAL_TIME_SKIP.isWithinSkipRange(hour, minute)) {
             log.info("🕒 새벽 {}시 {}분 ~ {}분 사이에는 실시간 스케줄러를 실행하지 않습니다.",
                 SchedulerSkipTime.REAL_TIME_SKIP.getSkipHour(),

--- a/src/main/java/com/example/excluzscheduler/domain/store/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/store/repository/StoreRepository.java
@@ -1,7 +1,14 @@
 package com.example.excluzscheduler.domain.store.store.repository;
 
+import java.util.List;
+
 import com.example.excluzscheduler.common.entity.Store;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, Integer> {
+
+	// 여러 개의 Store ID를 한 번에 조회하는 메서드 추가 (N+1 문제 해결)
+	List<Store> findByIdIn(List<Integer> ids);
+
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/StoreRankingController.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/StoreRankingController.java
@@ -4,10 +4,12 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
 import com.example.excluzscheduler.domain.store.storeRanking.service.StoreRankingService;
+import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,9 +19,13 @@ import lombok.RequiredArgsConstructor;
 public class StoreRankingController {
 	private final StoreRankingService storeRankingService;
 
-	// TOP 10 랭킹 조회
+	// TOP 10 랭킹 조회 (매출 정보 제외)
+	// RequestParam value의 enum(DAY, MONTH, YEAR)에 따라 동적으로 조회 가능
 	@GetMapping("/top10")
-	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings() {
-		return storeRankingService.getTop10StoreRankings();
+	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings(
+		@RequestParam(value = "period", defaultValue = "DAY") String period
+	) {
+		RevenuePeriod revenuePeriod = RevenuePeriod.valueOf(period.toUpperCase());
+		return storeRankingService.getTop10StoreRankings(revenuePeriod);
 	}
 }

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/StoreRankingController.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/StoreRankingController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class StoreRankingController {
 	private final StoreRankingService storeRankingService;
 
-	// 매일 자정마다 실행되는 스케줄러 (TOP 10 랭킹 업데이트)
+	// TOP 10 랭킹 조회
 	@GetMapping("/top10")
 	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings() {
 		return storeRankingService.getTop10StoreRankings();

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/repository/StoreRankingRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/repository/StoreRankingRepository.java
@@ -1,5 +1,6 @@
 package com.example.excluzscheduler.domain.store.storeRanking.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -16,8 +17,12 @@ import com.example.excluzscheduler.domain.store.storeRevenue.enums.RevenuePeriod
 @Repository
 public interface StoreRankingRepository extends JpaRepository<StoreRanking, Long> {
 
-	// 기존 랭킹 존재 여부 확인
+	// 기존 랭킹 존재 여부 확인 (개별 스토어 랭킹 조회)
 	Optional<StoreRanking> findByStoreAndRankingPeriod(Store store, RevenuePeriod rankingPeriod);
+
+	// 특정 랭킹 기간에 대한 전체 랭킹 조회
+	@Query("SELECT sr FROM StoreRanking sr WHERE sr.rankingPeriod = :period ORDER BY sr.rankPosition ASC")
+	Page<StoreRanking> findByRankingPeriod(@Param("period") RevenuePeriod period, Pageable pageable);
 
 	// TOP 10 랭킹 조회 (매출 정보 없이 반환)
 	@Query("SELECT sr FROM StoreRanking sr WHERE sr.rankingPeriod = :period ORDER BY sr.rankPosition ASC")

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
@@ -13,8 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.excluzscheduler.common.entity.Store;
 import com.example.excluzscheduler.common.entity.StoreRanking;
-import com.example.excluzscheduler.common.entity.StoreRevenue;
-import com.example.excluzscheduler.common.entity.StoreSettlement;
 import com.example.excluzscheduler.domain.store.store.repository.StoreRepository;
 import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
 import com.example.excluzscheduler.domain.store.storeRanking.repository.StoreRankingRepository;
@@ -38,7 +36,7 @@ public class StoreRankingService {
 	 * 2. 매출이 동일하지 않은 이후 스토어가 있는 경우, (동일한 등수 + 동일한 스토어의 수) 만큼의 등수를 얻는다 -> 1등이 2개면, 다음 등수는 3등 처리
 	 */
 	@Transactional
-	public void updateDailyStoreRankings(
+	public void updateStoreRankings(
 		RevenuePeriod rankingPeriod, LocalDateTime startDateTime, LocalDateTime endDateTime
 	) {
 		log.info("🔍 매출 기준 TOP10 가져오는 중...");
@@ -115,7 +113,7 @@ public class StoreRankingService {
 	// TOP 10 랭킹 조회 (매출 정보 제외)
 	@Transactional(readOnly = true)
 	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings() {
-		return storeRankingRepository.findTop10ByRankingPeriod(RevenuePeriod.MINUTE_1, PageRequest.of(0, 10))
+		return storeRankingRepository.findTop10ByRankingPeriod(RevenuePeriod.MONTH, PageRequest.of(0, 10))
 			.getContent()
 			.stream()
 			.map(ranking -> new StoreRankingTop10ResponseDto(

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
@@ -38,9 +38,9 @@ public class StoreRankingService {
 		log.info("🔍 매출 기준 TOP10 가져오는 중...");
 
 		// 어제 매출 기준으로 TOP 10 스토어 조회
-		List<StoreRevenue> topStores = storeRevenueRepository.findStoresByRevenue(startDatetime, endDatetime);
+		List<StoreRevenue> storeRevenueListInDescendingOrder = storeRevenueRepository.findStoreRevenuesByPeriod(startDatetime, endDatetime);
 
-		if (topStores.isEmpty()) {
+		if (storeRevenueListInDescendingOrder.isEmpty()) {
 			log.info("⚠️ 매출 데이터가 없습니다. 랭킹을 업데이트하지 않습니다.");
 			return;
 		}
@@ -52,9 +52,9 @@ public class StoreRankingService {
 
 		int preStoreRank = currentRank;
 
-		for (StoreRevenue revenue : topStores) {
-			Store store = storeRepository.findById(revenue.getStoreId())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스토어입니다.")); // todo 추후 커스텀 익셉션 처리
+		for (StoreRevenue revenue : storeRevenueListInDescendingOrder) {
+			Store store = storeRepository.findById(revenue.getStoreId()) // todo <- 계속 조회를 해 오기 때문에 속도 느림(N+1 개선 필요, 예외처리는 필요)
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스토어입니다."));
 
 			int rank = currentRank;
 
@@ -63,7 +63,7 @@ public class StoreRankingService {
 			}
 
 			// 기존 랭킹 존재 여부 확인
-			StoreRanking existingRanking = storeRankingRepository.findByStoreAndRankingPeriod(store, rankingPeriod)
+			StoreRanking existingRanking = storeRankingRepository.findByStoreAndRankingPeriod(store, rankingPeriod) // todo 개선(N+1 문제 발생 가능) <- 조회 최소화시키기
 				.orElse(null);
 
 			if (existingRanking != null) {
@@ -78,7 +78,7 @@ public class StoreRankingService {
 					.revenue(revenue.getTotalRevenue())
 					.build();
 
-				storeRankingRepository.save(newRanking);
+				storeRankingRepository.save(newRanking); // todo 수정하기(N+1이라고 생각하기) <- 뭐든지 for문 밖에서 일어나게(DB 조회, 생성 등)
 			}
 
 			preStoreRevenue = revenue.getTotalRevenue();

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
@@ -1,7 +1,10 @@
 package com.example.excluzscheduler.domain.store.storeRanking.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
@@ -11,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.excluzscheduler.common.entity.Store;
 import com.example.excluzscheduler.common.entity.StoreRanking;
 import com.example.excluzscheduler.common.entity.StoreRevenue;
+import com.example.excluzscheduler.common.entity.StoreSettlement;
 import com.example.excluzscheduler.domain.store.store.repository.StoreRepository;
 import com.example.excluzscheduler.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
 import com.example.excluzscheduler.domain.store.storeRanking.repository.StoreRankingRepository;
@@ -34,58 +38,76 @@ public class StoreRankingService {
 	 * 2. 매출이 동일하지 않은 이후 스토어가 있는 경우, (동일한 등수 + 동일한 스토어의 수) 만큼의 등수를 얻는다 -> 1등이 2개면, 다음 등수는 3등 처리
 	 */
 	@Transactional
-	public void updateDailyStoreRankings(RevenuePeriod rankingPeriod, LocalDateTime startDatetime, LocalDateTime endDatetime) {
+	public void updateDailyStoreRankings(
+		RevenuePeriod rankingPeriod, LocalDateTime startDateTime, LocalDateTime endDateTime
+	) {
 		log.info("🔍 매출 기준 TOP10 가져오는 중...");
 
-		// 어제 매출 기준으로 TOP 10 스토어 조회
-		List<StoreRevenue> storeRevenueListInDescendingOrder = storeRevenueRepository.findStoreRevenuesByPeriod(startDatetime, endDatetime);
+		// 스토어별 매출 합계를 한 번에 조회
+		List<Object[]> storeRevenueList = storeRevenueRepository.findTotalRevenueWithPeriod(startDateTime, endDateTime, rankingPeriod);
 
-		if (storeRevenueListInDescendingOrder.isEmpty()) {
+		if (storeRevenueList.isEmpty()) {
 			log.info("⚠️ 매출 데이터가 없습니다. 랭킹을 업데이트하지 않습니다.");
-			return;
+			throw new IllegalStateException("매출 데이터가 존재하지 않아 랭킹을 업데이트할 수 없습니다."); // todo 추후 커스텀 익셉션 처리하기
 		}
 
+		// 기존 랭킹 데이터 조회 및 Map 변환 (N+1 방지)
+		List<StoreRanking> existingRankings = storeRankingRepository.findByRankingPeriod(rankingPeriod, PageRequest.of(0, 1000)).getContent();
+		Map<Integer, StoreRanking> rankingMap = existingRankings.stream()
+			.collect(Collectors.toMap(ranking -> ranking.getStore().getId(), Function.identity()));
+
+		// 스토어 ID로 Store 정보 한 번에 조회 (N+1 방지)
+		List<Integer> storeIdList = storeRevenueList.stream()
+			.map(row -> (Integer) row[0])
+			.collect(Collectors.toList());
+		Map<Integer, Store> storeMap = storeRepository.findByIdIn(storeIdList).stream()
+			.collect(Collectors.toMap(Store::getId, Function.identity()));
+
+		// 랭킹 계산을 위한 변수들
+		List<StoreRanking> newRankings = new ArrayList<>();
 		int currentRank = 1;
+		Long previousRevenue = -1L;
+		int previousRank = currentRank;
 
-		// 이전 매출 저장
-		Long preStoreRevenue = -1L; // 초기화
+		for (Object[] row : storeRevenueList) {
+			Integer storeId = (Integer) row[0];
+			Long totalRevenue = (Long) row[1];
 
-		int preStoreRank = currentRank;
-
-		for (StoreRevenue revenue : storeRevenueListInDescendingOrder) {
-			Store store = storeRepository.findById(revenue.getStoreId()) // todo <- 계속 조회를 해 오기 때문에 속도 느림(N+1 개선 필요, 예외처리는 필요)
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스토어입니다."));
-
-			int rank = currentRank;
-
-			if (preStoreRevenue.equals(revenue.getTotalRevenue())) {
-				rank = preStoreRank;
+			Store store = storeMap.get(storeId);
+			if (store == null) {
+				log.warn("⚠️ 존재하지 않는 스토어 ID: {}", storeId);
+				continue;
 			}
 
-			// 기존 랭킹 존재 여부 확인
-			StoreRanking existingRanking = storeRankingRepository.findByStoreAndRankingPeriod(store, rankingPeriod) // todo 개선(N+1 문제 발생 가능) <- 조회 최소화시키기
-				.orElse(null);
+			// 동점 처리 로직
+			if (previousRevenue.equals(totalRevenue)) {
+				currentRank = previousRank; // 같은 매출이면 같은 랭킹 유지
+			} else {
+				previousRank = currentRank; // 다른 매출이 나오면 새로운 랭킹 적용
+			}
+
+			StoreRanking existingRanking = rankingMap.get(storeId);
 
 			if (existingRanking != null) {
 				// 기존 랭킹 업데이트
-				existingRanking.updateRank(rank, revenue.getTotalRevenue());
+				existingRanking.updateRank(currentRank, totalRevenue);
 			} else {
 				// 새로운 랭킹 생성
 				StoreRanking newRanking = StoreRanking.builder()
 					.store(store)
 					.rankingPeriod(rankingPeriod)
-					.rankPosition(rank)
-					.revenue(revenue.getTotalRevenue())
+					.rankPosition(currentRank)
+					.revenue(totalRevenue)
 					.build();
-
-				storeRankingRepository.save(newRanking); // todo 수정하기(N+1이라고 생각하기) <- 뭐든지 for문 밖에서 일어나게(DB 조회, 생성 등)
+				newRankings.add(newRanking);
 			}
 
-			preStoreRevenue = revenue.getTotalRevenue();
-			preStoreRank = rank;
-
-			currentRank++;
+			previousRevenue = totalRevenue;
+			currentRank = previousRank + 1; // 다음 순위는 "현재 랭킹 + 1"이지만, 동점이면 그대로 유지
 		}
+
+		// 한 번에 저장 (N+1 방지)
+		storeRankingRepository.saveAll(newRankings);
 
 		log.info("✅ 매출 기준 TOP10 가져오기 완료!");
 	}

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRanking/service/StoreRankingService.java
@@ -112,8 +112,8 @@ public class StoreRankingService {
 
 	// TOP 10 랭킹 조회 (매출 정보 제외)
 	@Transactional(readOnly = true)
-	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings() {
-		return storeRankingRepository.findTop10ByRankingPeriod(RevenuePeriod.MONTH, PageRequest.of(0, 10))
+	public List<StoreRankingTop10ResponseDto> getTop10StoreRankings(RevenuePeriod period) {
+		return storeRankingRepository.findTop10ByRankingPeriod(period, PageRequest.of(0, 10))
 			.getContent()
 			.stream()
 			.map(ranking -> new StoreRankingTop10ResponseDto(

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/enums/RevenuePeriod.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/enums/RevenuePeriod.java
@@ -4,15 +4,10 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 
-public enum RevenuePeriod {
-    MINUTE_1(ChronoUnit.MINUTES, 1),
-    MINUTE_2(ChronoUnit.MINUTES, 2),
-    MINUTE_10(ChronoUnit.MINUTES, 10),
-    HOUR_1(ChronoUnit.HOURS, 1),
-    DAY_1(ChronoUnit.DAYS, 1),
-    WEEK_1(ChronoUnit.WEEKS, 1),
-    MONTH_1(ChronoUnit.MONTHS, 1),
-    YEAR_1(ChronoUnit.YEARS, 1);
+    public enum RevenuePeriod {
+    DAY(ChronoUnit.DAYS, 1),
+    MONTH(ChronoUnit.MONTHS, 1),
+    YEAR(ChronoUnit.YEARS, 1);
 
     private final ChronoUnit unit;  // 시간 단위 (분, 시간, 일 등)
     private final long amount;       // 해당 단위의 기간 (1분, 2분, 1시간 등)

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
@@ -12,10 +12,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface StoreRevenueRepository extends JpaRepository<StoreRevenue, Integer> {
 
-	// 매출 기준으로 스토어 조회
-	@Query("SELECT sr FROM StoreRevenue sr WHERE sr.id.startDatetime >= :startDate AND sr.id.endDatetime < :endDate ORDER BY sr.totalRevenue DESC")
-	List<StoreRevenue> findStoreRevenuesByPeriod(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
+	// 특정 기간 동안 스토어별 매출 합산 조회
 	@Query("SELECT sr.id.storeId, SUM(sr.totalRevenue) " +
 	"FROM StoreRevenue sr " +
 	"WHERE (sr.id.startDatetime = :startDateTime) " +

--- a/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
+++ b/src/main/java/com/example/excluzscheduler/domain/store/storeRevenue/repository/StoreRevenueRepository.java
@@ -13,5 +13,6 @@ public interface StoreRevenueRepository extends JpaRepository<StoreRevenue, Inte
 
 	// 매출 기준으로 스토어 조회
 	@Query("SELECT sr FROM StoreRevenue sr WHERE sr.startDatetime >= :startDate AND sr.endDatetime < :endDate ORDER BY sr.totalRevenue DESC")
-	List<StoreRevenue> findStoresByRevenue(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+	List<StoreRevenue> findStoreRevenuesByPeriod(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
 }


### PR DESCRIPTION
## 목적
- 스케줄러 실행 시 중복 실행을 방지하고 최적화하기 위해 개선
- 스토어 랭킹 조회 시 동적 필터링을 적용하여 유연한 조회 기능 제공
- 코드 가독성과 유지보수성을 높이기 위한 Enum 및 cron 상수 적용

## 변경점
1. 스케줄러 실행 최적화
- SchedulerSkipTime Enum을 추가하여 새벽 3시~3시 20분 사이에는 실시간 스케줄러 실행 방지
- 일간/월간/연간 스케줄러의 실행 시간을 조정하여 부하 분산 (03:00, 03:10, 03:20 실행)

2. 스토어 랭킹 조회 기능 개선
- TOP10 랭킹 조회 API에서 period 파라미터를 받아 일간, 월간, 연간 랭킹을 동적으로 조회할 수 있도록 수정
- `RevenuePeriod.valueOf(period.toUpperCase())`를 사용하여 유연한 조회 지원

3. 가독성과 유지보수성 향상
- `SchedulerSkipTime` Enum을 통해 특정 시간 동안 실행을 제한하는 로직을 분리하여 관리
- `cron` 표현식을 상수(`CRON_DAILY`, `CRON_MONTHLY`, `CRON_YEARLY`)로 정의하여 유지보수 용이

## 리뷰어에게
개선된 스케줄러 실행 로직이 의도한 대로 동작할지 확인 부탁드립니다.